### PR TITLE
code coverage and custom pssa rules

### DIFF
--- a/Pester-step.yml
+++ b/Pester-step.yml
@@ -65,11 +65,19 @@ steps:
     Invoke-Pester @Options
   displayName: Invoke-Pester
 
+- powershell: |
+    #normalize source dir for code coverage
+    $sourceDirs = (@(Get-ChildItem ${{ parameters.codeCoverageDirectory }} -Directory -Recurse | Convert-Path) + "${{ parameters.codeCoverageDirectory }}") -join ";"
+    Write-Host "INFO [task.setvariable variable=CodeCoverageRecurseDirectories]$sourceDirs"
+    Write-Host "##vso[task.setvariable variable=CodeCoverageRecurseDirectories]$sourceDirs"
+    #}
+  displayName: Normalize Source Directory for Code Coverage Report
+
 - task: PublishCodeCoverageResults@1
   displayName: Publish Code Coverage
   inputs:
     summaryFileLocation: '$(Common.TestResultsDirectory)/Coverage-$(Build.SourceVersion).xml'
-    pathToSources: ${{ parameters.codeCoverageDirectory }}
+    pathToSources: $(CodeCoverageRecurseDirectories)
     failIfCoverageEmpty: true
   condition: |
     and(
@@ -87,4 +95,3 @@ steps:
     failTaskOnFailedTests: true
     testRunTitle: "${{ parameters.testRunTitle }} on $(PSPlatform)"
   condition: succeededOrFailed()
-

--- a/ScriptAnalyzer-job.yml
+++ b/ScriptAnalyzer-job.yml
@@ -97,7 +97,7 @@ jobs:
 
           forEach ($Rule in $ScriptAnalyzer.Rules.RuleName) {
             It "Passes $Rule" {
-              if ($Failures = $ScriptAnalyzer.Results.Where( {$_.RuleName -EQ "$Rule"})) {
+              if ($Failures = $ScriptAnalyzer.Results.Where( {$_.RuleName -like "*$Rule"})) {
                 throw ([Management.Automation.ErrorRecord]::new(
                   ([Exception]::new(($Failures.ForEach{$_.ScriptName + ":" + $_.Line + " " + $_.Message} -join "`n"))),
                   "ScriptAnalyzerViolation",


### PR DESCRIPTION
fixes #2 
fixes #3 

PR of the solutions I expressed in both of those incidents.  I tested this in a project of mine but it occurs to me it's a private project so I can't share the results with you, but it is generating the Code Coverage report properly and it is properly failing when I violate my custom PSSA rules.